### PR TITLE
SE-455 Lusid Drive Url Env Var Change

### DIFF
--- a/sdk/Lusid.Drive.Sdk/Utilities/ApiConfiguration.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/ApiConfiguration.cs
@@ -31,9 +31,9 @@
         public string ClientSecret { get;  set; }
 
         /// <summary>
-        /// LUSID Api Url
+        /// LUSID Drive Url
         /// </summary>
-        public string ApiUrl { get; set; }
+        public string DriveUrl { get; set; }
 
         /// <summary>
         /// Client Application name

--- a/sdk/Lusid.Drive.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -24,7 +24,7 @@ namespace Lusid.Drive.Sdk.Utilities
             var apiConfig = new ApiConfiguration
             {
                 TokenUrl = Environment.GetEnvironmentVariable("FBN_TOKEN_URL")?? Environment.GetEnvironmentVariable("fbn_token_url"),
-                ApiUrl = Environment.GetEnvironmentVariable("FBN_LUSID_API_URL") ?? Environment.GetEnvironmentVariable("fbn_lusid_api_url"),
+                DriveUrl = Environment.GetEnvironmentVariable("FBN_LUSID_DRIVE_URL") ?? Environment.GetEnvironmentVariable("fbn_lusid_drive_url"),
                 ClientId = Environment.GetEnvironmentVariable("FBN_CLIENT_ID") ?? Environment.GetEnvironmentVariable("fbn_client_id"),
                 ClientSecret = Environment.GetEnvironmentVariable("FBN_CLIENT_SECRET") ?? Environment.GetEnvironmentVariable("fbn_client_secret"),
                 Username = Environment.GetEnvironmentVariable("FBN_USERNAME") ?? Environment.GetEnvironmentVariable("fbn_username"),
@@ -37,7 +37,7 @@ namespace Lusid.Drive.Sdk.Utilities
                 string.IsNullOrEmpty(apiConfig.Password) ||
                 string.IsNullOrEmpty(apiConfig.ClientId) ||
                 string.IsNullOrEmpty(apiConfig.ClientSecret) ||
-                string.IsNullOrEmpty(apiConfig.ApiUrl))
+                string.IsNullOrEmpty(apiConfig.DriveUrl))
             {
                 var config = new ConfigurationBuilder()
                     .SetBasePath(Directory.GetCurrentDirectory())

--- a/sdk/Lusid.Drive.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/LusidApiFactory.cs
@@ -35,16 +35,16 @@ namespace Lusid.Drive.Sdk.Utilities
                 throw new UriFormatException($"Invalid Token Uri: {apiConfiguration.TokenUrl}");
             }
 
-            if (!Uri.TryCreate(apiConfiguration.ApiUrl, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(apiConfiguration.DriveUrl, UriKind.Absolute, out var _))
             {
-                throw new UriFormatException($"Invalid LUSID Uri: {apiConfiguration.ApiUrl}");
+                throw new UriFormatException($"Invalid LUSID Drive Uri: {apiConfiguration.DriveUrl}");
             }
 
             // Create configuration
             var tokenProvider = new ClientCredentialsFlowTokenProvider(apiConfiguration);
             var configuration = new TokenProviderConfiguration(tokenProvider)
             {
-                BasePath = apiConfiguration.ApiUrl,
+                BasePath = apiConfiguration.DriveUrl,
             };
             
             configuration.AddDefaultHeader("X-LUSID-Application", apiConfiguration.ApplicationName);

--- a/sdk/Lusid.Drive.Sdk/Utilities/LusidApiFactoryBuilder.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/LusidApiFactoryBuilder.cs
@@ -24,7 +24,7 @@ namespace Lusid.Drive.Sdk.Utilities
         {
             Configuration config = new GlobalConfiguration
             {
-                BasePath = Environment.GetEnvironmentVariable("BASE_PATH") ?? Environment.GetEnvironmentVariable("base_path"),
+                BasePath = Environment.GetEnvironmentVariable("FBN_DRIVE_API_URL") ?? Environment.GetEnvironmentVariable("fbn_drive_api_url"),
                 AccessToken = Environment.GetEnvironmentVariable("FBN_ACCESS_TOKEN") ?? Environment.GetEnvironmentVariable("fbn_access_token")
             };
             return new LusidApiFactory(config);


### PR DESCRIPTION
Changing environment variable and secrets parameters to retrieve LUSID Drive URL from FBN_LUSID_API_URL to FBN_LUSID_DRIVE_URL to prevent any clashes when using both lusid api and drive sdks within an application.

For access token usage updating env variable from BASE_PATH to FBN_LUSID_DRIVE_URL  to keep consistent with python drive sdk and general sdk naming pattern for url parameter

Will require a corresponding update to Drive concourse build