### PR TITLE
DEV-10663: handle refresh token

### DIFF
--- a/sdk/Lusid.Drive.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/TokenProviderTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using Lusid.Drive.Sdk.Utilities;
+using NUnit.Framework;
+
+namespace Lusid.Drive.Sdk.Tests
+{
+    public class TokenProviderTests
+    {
+        private static readonly Lazy<ApiConfiguration> ApiConfig =
+            new Lazy<ApiConfiguration>(() => ApiConfigurationBuilder.Build("secrets.json"));
+
+        [Test]
+        public async Task CanGetNewTokenWhenRefreshTokenExpired()
+        {
+            var provider = new ClientCredentialsFlowTokenProvider(ApiConfig.Value);
+            var _ = await provider.GetAuthenticationTokenAsync();
+            var firstTokenDetails = provider.GetLastToken();
+
+            Assert.That(firstTokenDetails.RefreshToken, Is.Not.Null.And.Not.Empty, "refresh_token not returned so unable to verify refresh behaviour.");
+
+            Console.WriteLine($"Token expiring at {firstTokenDetails.ExpiresOn:o}");
+
+            // WHEN we pretend to delay until both...
+            // (1) the original token has expired (for expediency update the expires_on on the token)
+            provider.ExpireToken();
+            // (2) the refresh token has expired (for expediency update the refresh_token to an invalid value that will not be found)
+            provider.GetLastToken().RefreshToken = "InvalidRefreshToken";
+            Assert.That(DateTimeOffset.UtcNow, Is.GreaterThan(firstTokenDetails.ExpiresOn));
+            var refreshedToken = await provider.GetAuthenticationTokenAsync();
+
+            // THEN it should be populated, and the ExpiresOn should be in the future
+            Assert.That(refreshedToken, Is.Not.Empty);
+            Assert.That(provider.GetLastToken().ExpiresOn, Is.GreaterThan(DateTimeOffset.UtcNow));
+        }
+    }
+}

--- a/sdk/Lusid.Drive.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
@@ -45,7 +46,7 @@ namespace Lusid.Drive.Sdk.Utilities
             }
             public string Token { get; }
             public DateTimeOffset ExpiresOn { get; internal set; }
-            public string RefreshToken { get; }
+            public string RefreshToken { get; internal set; }
         }
 
         
@@ -184,6 +185,12 @@ namespace Lusid.Drive.Sdk.Utilities
                 // Send request
                 var response = await httpClient.SendAsync(tokenRequest);
                 var body = await response.Content.ReadAsStringAsync();
+
+                if (response.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    // Unable to refresh token so obtain a brand new one using username/password
+                    return await GetNewToken(apiConfig);
+                }
 
                 if (!response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
Handle the Drive SDK credentials refresh in the same way as the LUSID SDK.