### PR TITLE
DEV-10488: Adding a CreateFile method to use a Stream instead of byte[]

### DIFF
--- a/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
@@ -15,7 +15,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
         }
 
         [Test]

--- a/sdk/Lusid.Drive.Sdk.Tests/FilesApiExtensionsTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FilesApiExtensionsTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Lusid.Drive.Sdk.Api;
+using Lusid.Drive.Sdk.Client;
+using Lusid.Drive.Sdk.Extensions;
+using Lusid.Drive.Sdk.Model;
+using Lusid.Drive.Sdk.Utilities;
+using NUnit.Framework;
+
+namespace Lusid.Drive.Sdk.Tests
+{
+    [TestFixture]
+    public class ExtensionTests
+    {
+        private string _testFolderName;
+        private ILusidApiFactory _factory;
+        private IFoldersApi _foldersApi;
+        private IFilesApi _filesApi;
+        private string _testFolderId;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _testFolderName = "Test_Folder" + Guid.NewGuid();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _filesApi = _factory.Api<IFilesApi>();
+            _foldersApi = _factory.Api<IFoldersApi>();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testFolderId = _foldersApi.GetRootFolder(filter: $"Name eq '{_testFolderName}'").Values.SingleOrDefault()?.Id;
+            var createFolder = new CreateFolder("/", _testFolderName);
+            _testFolderId ??= _foldersApi.CreateFolder(createFolder).Id;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _foldersApi.DeleteFolder(_testFolderId);
+        }
+        
+        [Test]
+        public void UploadAsStreamAsync_EmptyStream_Throws400()
+        {
+            var data = new MemoryStream();
+
+            //Create a unique file name
+            var fileName = Guid.NewGuid().ToString();
+
+            //Upload an empty Stream
+            var exception = Assert.ThrowsAsync<ApiException>(() =>
+                _filesApi.UploadAsStreamAsync(fileName, "/",  (int) data.Length, data));
+            Assert.AreEqual(exception.ErrorCode, 400);
+        }
+        
+        [Test]
+        public void DownloadAsStreamAsync_IncorrectId_Throws404()
+        {
+            //Download a file that doesn't exist
+            var exception = Assert.ThrowsAsync<ApiException>(() => 
+                _filesApi.DownloadAsStreamAsync(Guid.NewGuid().ToString()));
+            Assert.AreEqual(exception.ErrorCode, 404);
+        }
+
+        [Test]
+        public void DownloadAsStreamAsync_WrongFormatId_Throws400()
+        {
+            //Download a file with an non Guid ID
+            var exception = Assert.ThrowsAsync<ApiException>(() => _filesApi.DownloadAsStreamAsync("NotAnProperId"));
+            Assert.AreEqual(exception.ErrorCode, 400);
+        }
+    }
+}

--- a/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
@@ -16,7 +16,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
             _filesApi = _factory.Api<IFilesApi>();
             var foldersApi = _factory.Api<IFoldersApi>();
 

--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
@@ -18,7 +18,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
             _foldersApi = _factory.Api<IFoldersApi>();
 
             _testFolderId = _foldersApi.GetRootFolder(filter: "Name eq 'SDK_Test_Folder'").Values.SingleOrDefault()?.Id;

--- a/sdk/Lusid.Drive.Sdk.Tests/Tutorials/FilesTutorial.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/Tutorials/FilesTutorial.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Lusid.Drive.Sdk.Api;
+using Lusid.Drive.Sdk.Extensions;
 using Lusid.Drive.Sdk.Model;
 using Lusid.Drive.Sdk.Utilities;
 using NUnit.Framework;
@@ -58,6 +62,20 @@ namespace Lusid.Drive.Sdk.Tests.Tutorials
 
             Assert.AreEqual(fileName, upload.Name);
         }
+        
+        [Test]
+        public async Task Upload_File_As_Stream()
+        {
+            var data = new MemoryStream(Encoding.UTF8.GetBytes("a,b \n c,d"));
+
+            //Create a unique file name
+            var fileName = Guid.NewGuid().ToString();
+
+            //Upload a file
+            var upload = await _filesApi.UploadAsStreamAsync(fileName, "/",  (int) data.Length, data);
+             
+            Assert.AreEqual(fileName, upload.Name);
+        }
 
         [Test]
         public void Delete_File()
@@ -98,6 +116,23 @@ namespace Lusid.Drive.Sdk.Tests.Tutorials
             _filesApi.DownloadFile(upload.Id).Read(downloadedFile);
 
             Assert.AreEqual(uploadedFile, downloadedFile);
+        }
+
+        [Test]
+        public async Task Download_File_As_Stream()
+        {
+            var data = new MemoryStream(Encoding.UTF8.GetBytes("a,b \n c,d"));
+
+            //Create a unique file name
+            var fileName = Guid.NewGuid().ToString();
+
+            //Upload a file
+            var upload = await _filesApi.UploadAsStreamAsync(fileName, "/",  (int) data.Length, data);
+
+            //Download the file that was just uploaded
+            var downloadedData = await _filesApi.DownloadAsStreamAsync(upload.Id);
+            
+            Assert.AreEqual(data, downloadedData);
         }
 
         [Test]

--- a/sdk/Lusid.Drive.Sdk/Extensions/FilesApiExtensions.cs
+++ b/sdk/Lusid.Drive.Sdk/Extensions/FilesApiExtensions.cs
@@ -1,0 +1,256 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Lusid.Drive.Sdk.Api;
+using Lusid.Drive.Sdk.Client;
+using Lusid.Drive.Sdk.Model;
+using RestSharp.Portable;
+using RestSharp.Portable.HttpClient.Impl.Http;
+
+namespace Lusid.Drive.Sdk.Extensions
+{
+    /// <summary>
+    /// Represents a collection of Extension Methods to interact with Rest Sharp using a Stream instead of a byte array
+    /// </summary>
+    public static class FilesApiExtensions
+    {
+        /// <summary>
+        ///     Uploads data to a file as a stream instead of as a byte array.
+        ///     The function is asynchronous as RestSharp only offers asynchronous methods.
+        ///     This method was created in order to support file uploads as Streams as this is less taxing on memory
+        ///     than byte arrays. This would be better for large file uploads or in the case where multiple users are
+        ///     uploading at the same time, causing a lot of memory to be consumed.
+        /// </summary>
+        /// <param name="xLusidDriveFilename">File name.</param>
+        /// <param name="xLusidDrivePath">File path.</param>
+        /// <param name="contentLength">The size in bytes of the file to be uploaded</param>
+        /// <param name="body">The data to upload</param>
+        /// <returns>Storage Object as a Task</returns>
+        public static async Task<StorageObject> UploadAsStreamAsync(this IFilesApi api,
+            string xLusidDriveFilename,
+            string xLusidDrivePath,
+            int? contentLength,
+            Stream body)
+        {
+            // Verify that 'xLusidDriveFilename' is set
+            if (xLusidDriveFilename == null)
+            {
+                throw new ApiException(400, 
+                    "Missing required parameter 'xLusidDriveFilename' when calling FilesApiExtensions->UploadAsStreamAsync");
+            }
+
+            // Verify that 'xLusidDrivePath' is set
+            if (xLusidDrivePath == null)
+            {
+                throw new ApiException(400,
+                    "Missing required parameter 'xLusidDrivePath' when calling FilesApiExtensions->UploadAsStreamAsync");
+            }
+
+            // Verify that 'contentLength' is set
+            if (contentLength == null)
+            {
+                throw new ApiException(400, 
+                    "Missing required parameter 'contentLength' when calling FilesApiExtensions->UploadAsStreamAsync");
+            }
+
+            // Endpoint to POST new file
+            const string fileApiEndpointPath = "./api/files";
+            
+            // Set default parameters
+            var localVarHeaderParams = new Dictionary<string, string>(api.Configuration.DefaultHeader);
+
+            // Set the Content-Type header
+            var localVarHttpContentTypes = new[] {"application/octet-stream"};
+            var localVarHttpContentType = api.Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // Set the Accept header
+            var localVarHttpHeaderAccepts = new[] {"text/plain", "application/json", "text/json"};
+            var localVarHttpHeaderAccept = api.Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            
+            if (localVarHttpHeaderAccept != null)
+            {
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+            }
+            
+            localVarHeaderParams.Add("x-lusid-drive-filename", api.Configuration.ApiClient.ParameterToString(xLusidDriveFilename));
+            localVarHeaderParams.Add("x-lusid-drive-path", api.Configuration.ApiClient.ParameterToString(xLusidDrivePath));
+            localVarHeaderParams.Add("Content-Length", api.Configuration.ApiClient.ParameterToString(contentLength));
+            
+            // Authentication (oauth2) required
+            if (!string.IsNullOrEmpty(api.Configuration.AccessToken))
+            {
+                localVarHeaderParams["Authorization"] = "Bearer " + api.Configuration.AccessToken;
+            }
+
+            // Set the LUSID header
+            localVarHeaderParams["X-LUSID-Sdk-Language"] = "C#";
+            localVarHeaderParams["X-LUSID-Sdk-Version"] = typeof(FilesApiExtensions).Assembly.GetName().Version?.ToString();
+
+            // Get a rest client
+            var restClient = api.Configuration.ApiClient.RestClient;
+            
+            // Create a rest request with the created parameters
+            var restRequest = new RestRequest(fileApiEndpointPath, Method.POST) {Serializer = null};
+
+            // Create a parameters list for the HTTP request message 
+            var parameters = CreateParameters(body, localVarHeaderParams, localVarHttpContentType);
+            
+            // Create a HTTP request message with a stream as content
+            var requestMessage = restClient.HttpClientFactory.CreateRequestMessage(restClient, restRequest, 
+            parameters);
+            requestMessage.Content = new DefaultHttpContent(new StreamContent(body));
+            requestMessage.Content.Headers.Add("Content-Length", api.Configuration.ApiClient.ParameterToString(contentLength));
+            
+            // Get a HTTP client from the rest client's HTTP client factory
+            var httpClient = restClient.HttpClientFactory.CreateClient(restClient);
+            
+            // Send the HTTP request message
+            var httpResponseMessage = await httpClient.SendAsync(requestMessage, CancellationToken.None);
+            
+            // Convert the HTTP response message to a REST response message
+            var restResponseMessage =
+                await RestResponse.CreateResponse(restClient, restRequest, httpResponseMessage, CancellationToken.None);
+
+            // Exception Handling
+            var exception = api.ExceptionFactory?.Invoke("UploadAsStreamAsync", restResponseMessage);
+            if (exception != null)
+            {
+                throw exception;
+            }
+
+            return (StorageObject) api.Configuration.ApiClient.Deserialize(restResponseMessage, typeof(StorageObject));
+        }
+        
+        /// <summary>
+        ///     Downloads data to a file as a stream instead of as a byte array.
+        ///     The function is asynchronous as RestSharp only offers asynchronous methods.
+        ///     This method was created in order to support file downloads as Streams as this is less taxing on memory
+        ///     than byte arrays. This would be better for large file downloads or in the case where multiple users are
+        ///     downloading at the same time, causing a lot of memory to be consumed.
+        /// </summary>
+        /// <param name="id">ID of the file to download</param>
+        /// <returns>The downloaded Stream as a Task</returns>
+        public static async Task<Stream> DownloadAsStreamAsync(this IFilesApi api, string id)
+        {
+            // verify the required parameter 'id' is set
+            if (id == null)
+            {
+                throw new ApiException(400, "Missing required parameter 'id' when calling FilesApiExtensions->DownloadAsStreamAsync");
+            }
+
+            // Endpoint to GET new file
+            const string fileApiEndpointPath = "./api/files/{id}/contents";
+            
+            // Set default parameters
+            var localVarPathParams = new Dictionary<string, string>();
+            var localVarHeaderParams = new Dictionary<string, string>(api.Configuration.DefaultHeader);
+
+            // Set the Content-Type header
+            string[] localVarHttpContentTypes = {};
+            string localVarHttpContentType = api.Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // Set the Accept header
+            string[] localVarHttpHeaderAccepts = {"text/plain", "application/json", "text/json"};
+            var localVarHttpHeaderAccept = api.Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            
+            if (localVarHttpHeaderAccept != null)
+            {
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+            }
+            
+            // Set the Path Parameter
+            localVarPathParams.Add("id", api.Configuration.ApiClient.ParameterToString(id)); // path parameter
+
+            // Authentication (oauth2) required
+            if (!string.IsNullOrEmpty(api.Configuration.AccessToken))
+            {
+                localVarHeaderParams["Authorization"] = "Bearer " + api.Configuration.AccessToken;
+            }
+
+            // Set the LUSID header
+            localVarHeaderParams["X-LUSID-Sdk-Language"] = "C#";
+            localVarHeaderParams["X-LUSID-Sdk-Version"] = typeof(FilesApiExtensions).Assembly.GetName().Version?.ToString();
+
+            // Get a rest client
+            var restClient = api.Configuration.ApiClient.RestClient;
+            
+            // Create a rest request with the created parameters
+            var restRequest = new RestRequest(fileApiEndpointPath, Method.GET) {Serializer = null};
+            foreach (var (key, value) in localVarPathParams)
+            {
+                restRequest.AddParameter(key, value, ParameterType.UrlSegment);
+            }
+
+            // Create a parameters list for the HTTP request message 
+            var parameters = CreateParameters(null, localVarHeaderParams, localVarHttpContentType);
+            
+            // Create a HTTP request message
+            var requestMessage = restClient.HttpClientFactory.CreateRequestMessage(restClient, restRequest, 
+            parameters);
+
+            // Get a HTTP client from the rest client's HTTP client factory
+            var httpClient = restClient.HttpClientFactory.CreateClient(restClient);
+            
+            // Send the HTTP request message
+            var httpResponseMessage = await httpClient.SendAsync(requestMessage, CancellationToken.None);
+                
+            // Convert the HTTP response message to a REST response message
+            var restResponseMessage =
+                await RestResponse.CreateResponse(restClient, restRequest, httpResponseMessage, CancellationToken.None);
+
+            // Exception Handling
+            var exception = api.ExceptionFactory?.Invoke("DownloadAsStreamAsync", restResponseMessage);
+            if (exception != null)
+            {
+                throw exception;
+            }
+
+            return (Stream) api.Configuration.ApiClient.Deserialize(restResponseMessage, typeof(Stream));
+        }
+
+        private static IList<Parameter> CreateParameters(
+            object postBody,
+            Dictionary<string, string> headerParams,
+            string contentType)
+        {
+            var parameters = new List<Parameter>();
+
+            // Add header parameters, except for the 'Content-Length' parameter - it's added directly to the
+            // HttpRequestMessage.Content property
+            foreach (var (key, value) in headerParams)
+            {
+                if (key != "Content-Length")
+                {
+                    parameters.Add(CreateParameter(key, value, ParameterType.HttpHeader));
+                }
+            }
+
+            // Add the stream as the body of the request
+            if (postBody != null)
+            {
+                parameters.Add(new Parameter
+                {
+                    Value = postBody, 
+                    Type = ParameterType.RequestBody, 
+                    ContentType = contentType
+                });
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        ///     Create a parameter for creating a http request message
+        /// </summary>
+        /// <param name="name">Name of the parameter</param>
+        /// <param name="value">Value of the parameter</param>
+        /// <param name="type">Type of the parameter</param>
+        /// <returns>The newly created parameter</returns>
+        private static Parameter CreateParameter(string name, object value, ParameterType type)
+        {
+            return new Parameter {Name = name, Value = value, Type = type};
+        }
+    }
+}

--- a/sdk/Lusid.Drive.Sdk/Lusid.Drive.Sdk.csproj
+++ b/sdk/Lusid.Drive.Sdk/Lusid.Drive.Sdk.csproj
@@ -26,13 +26,14 @@
   <ItemGroup>
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.8" />
     <PackageReference Include="FubarCoder.RestSharp.Portable.HttpClient" Version="4.0.8" />
+    <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0-preview.5.20278.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0-preview.5.20278.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="JsonSubTypes" Version="1.2.0" />
+    <PackageReference Include="JsonSubTypes" Version="1.8.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
JIRA: https://finbourne.atlassian.net/browse/DEV-10488

The SDK generator we use is based on RestSharp and does not support `Stream` (or not in the way the it is currently setup) - the SDK methods are using byte arrays that forces users to load the whole file content in memory. This can become an issue if users are trying to upload large files or if multiple users are trying to upload files at the same time because it consumes lots of memory and slows down the application for everybody else.

For a better user experience, I've added an upload method that supports a `Stream`.

I've also changed the `[OneTimeSetUp]` for `ApplicationMetadataTests`, `FilesApiTests`, and `FoldersApiTests` so that it takes in `secrets.json` instead of being 'fed' environmental variables.