### PR TITLE
DEV-10488: Got rid of the secrets.json file

### DIFF
--- a/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
@@ -15,7 +15,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = LusidApiFactoryBuilder.Build();
         }
 
         [Test]

--- a/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
@@ -16,7 +16,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = LusidApiFactoryBuilder.Build();
             _filesApi = _factory.Api<IFilesApi>();
             var foldersApi = _factory.Api<IFoldersApi>();
 
@@ -35,7 +35,7 @@ namespace Lusid.Drive.Sdk.Tests
             var create = _filesApi.CreateFile(fileName, "/SDK_Test_Folder", 50, data);
             Assert.That(create.Name, Is.EqualTo(fileName));
             Assert.That(create.Path, Is.EqualTo("/SDK_Test_Folder"));
-            
+
             var newName = Guid.NewGuid().ToString();
             var updateFile = new UpdateFile("/SDK_Test_Folder", newName);
             var update = _filesApi.UpdateFileMetadata(create.Id, updateFile);

--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
@@ -18,7 +18,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = LusidApiFactoryBuilder.Build();
             _foldersApi = _factory.Api<IFoldersApi>();
 
             _testFolderId = _foldersApi.GetRootFolder(filter: "Name eq 'SDK_Test_Folder'").Values.SingleOrDefault()?.Id;


### PR DESCRIPTION
Got rid of the secrets.json file so that the environmental are fetched instead of trying to be set by a json file that is in the .gitignore