### PR TITLE
IAM-331: download with retry (support virus scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ $ dotnet add package Lusid.Drive.Sdk.Preview
 ```
 
 For further documentation on building the SDK, running the tutorials and using the SDK please see the [wiki](https://github.com/finbourne/lusid-sdk-csharp-preview/wiki).
+
+### For running the Drive.Sdk.Tests
+
+* Create a `secrets.json` file (see the [wiki](https://github.com/finbourne/lusid-sdk-csharp-preview/wiki/API-credentials))
+* In `secrets.json` file, set `driveUrl` (Eg: ```"driveUrl": "https://www.lusid.com/drive"```)

--- a/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
@@ -15,7 +15,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
         }
 
         [Test]

--- a/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Lusid.Drive.Sdk.Api;
 using Lusid.Drive.Sdk.Client;
 using Lusid.Drive.Sdk.Model;
@@ -16,7 +17,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
             _filesApi = _factory.Api<IFilesApi>();
             var foldersApi = _factory.Api<IFoldersApi>();
 
@@ -26,7 +27,7 @@ namespace Lusid.Drive.Sdk.Tests
         }
 
         [Test]
-        public void Create_Rename_Download_Delete_File()
+        public async Task Create_Rename_Download_Delete_File()
         {
             var fileName = Guid.NewGuid().ToString();
             var rnd = new Random();
@@ -43,7 +44,8 @@ namespace Lusid.Drive.Sdk.Tests
             Assert.That(update.Path, Is.EqualTo("/SDK_Test_Folder"));
             Assert.That(update.Id, Is.EqualTo(create.Id));
 
-            var download = _filesApi.DownloadFile(update.Id);
+            var wait = new WaitForVirusScan(_filesApi);
+            var download = await wait.DownloadFileWithRetry(update.Id);
             var endData = new byte[50];
             download.Read(endData);
             Assert.That(endData, Is.EqualTo(data));

--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
@@ -18,7 +18,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build();
+            _factory = LusidApiFactoryBuilder.Build("secrets.json");
             _foldersApi = _factory.Api<IFoldersApi>();
 
             _testFolderId = _foldersApi.GetRootFolder(filter: "Name eq 'SDK_Test_Folder'").Values.SingleOrDefault()?.Id;

--- a/sdk/Lusid.Drive.Sdk.Tests/Lusid.Drive.Sdk.Tests.csproj
+++ b/sdk/Lusid.Drive.Sdk.Tests/Lusid.Drive.Sdk.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="secrets.json" CopyToOutputDirectory="Always" Condition="Exists('secrets.json')" />

--- a/sdk/Lusid.Drive.Sdk/Lusid.Drive.Sdk.csproj
+++ b/sdk/Lusid.Drive.Sdk/Lusid.Drive.Sdk.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
   
 </Project>

--- a/sdk/Lusid.Drive.Sdk/Utilities/LusidApiFactory.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/LusidApiFactory.cs
@@ -37,6 +37,11 @@ namespace Lusid.Drive.Sdk.Utilities
 
             if (!Uri.TryCreate(apiConfiguration.DriveUrl, UriKind.Absolute, out var _))
             {
+                if (string.IsNullOrEmpty(apiConfiguration.DriveUrl))
+                    throw new ArgumentNullException(
+                        nameof(apiConfiguration.DriveUrl),
+                        $"Drive Uri missing. Please specify either FBN_DRIVE_API_URL environment variable or driveUrl in secrets.json.");
+
                 throw new UriFormatException($"Invalid LUSID Drive Uri: {apiConfiguration.DriveUrl}");
             }
 

--- a/sdk/Lusid.Drive.Sdk/Utilities/WaitForVirusScan.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/WaitForVirusScan.cs
@@ -1,0 +1,53 @@
+﻿using Lusid.Drive.Sdk.Api;
+using Lusid.Drive.Sdk.Client;
+using Lusid.Drive.Sdk.Model;
+using Newtonsoft.Json;
+using Polly;
+using Polly.Retry;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lusid.Drive.Sdk.Utilities
+{
+    /// <summary>
+    /// Use polly library to retry and wait for file to pass virus scan
+    /// </summary>
+    public class WaitForVirusScan
+    {
+        private readonly IFilesApi _filesApi;
+        AsyncRetryPolicy _policy;
+
+        /// <summary>
+        /// Set retry policy to try up to 20 times, every 15 seconds.
+        /// </summary>
+        /// <param name="filesApi"></param>
+        public WaitForVirusScan(IFilesApi filesApi)
+        {
+            _filesApi = filesApi;
+            _policy = 
+                Policy
+                .Handle<ApiException>(e => e.ErrorCode == 423 /* Virus scan in progress */)
+                .WaitAndRetryAsync(
+                    20,
+                    sleepDurationProvider: (retryNumber) =>
+                    {
+                        Console.WriteLine($"retrying {retryNumber}");
+                        return TimeSpan.FromSeconds(15);
+                    });
+        }
+
+        /// <summary>
+        /// Asynchronously download file with a retry
+        /// </summary>
+        /// <param name="fileId"></param>
+        /// <returns></returns>
+        public async Task<Stream> DownloadFileWithRetry(string fileId)
+        {
+            var r = await _policy.ExecuteAsync(async () => await _filesApi.DownloadFileAsync(fileId));
+            return r;
+        }
+    }    
+}


### PR DESCRIPTION
- Addition of polly for catching `ApiException` and retrying file download whilst virus scan is in progress.
- Use `secrets.json` across all tests for consistency
- Addition of instructions in README for helping configure tests against drive API
- Improve error message in LusidApiFactory when DriveUrl is missing.

Error message before:
```OneTimeSetUp: System.UriFormatException : Invalid LUSID Drive Uri: ```

Error message after:
```OneTimeSetUp: System.ArgumentNullException : Drive Uri missing. Please specify either FBN_DRIVE_API_URL environment variable or driveUrl in secrets.json. (Parameter 'DriveUrl')```
