### PR TITLE
IAM-331: pipeline fix

### DIFF
--- a/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/ApplicationMetadataTests.cs
@@ -15,7 +15,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = EnvironmentCheck.FactoryForEnvironment();
         }
 
         [Test]

--- a/sdk/Lusid.Drive.Sdk.Tests/EnvironmentCheck.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/EnvironmentCheck.cs
@@ -1,0 +1,18 @@
+﻿using Lusid.Drive.Sdk.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Lusid.Drive.Sdk.Tests
+{
+    public static class EnvironmentCheck
+    {
+        public static ILusidApiFactory FactoryForEnvironment()
+        {
+            return 
+                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FBN_ACCESS_TOKEN")) ?
+                    LusidApiFactoryBuilder.Build("secrets.json") :
+                    LusidApiFactoryBuilder.Build();
+        }
+    }
+}

--- a/sdk/Lusid.Drive.Sdk.Tests/FilesApiExtensionsTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FilesApiExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace Lusid.Drive.Sdk.Tests
         public void OneTimeSetUp()
         {
             _testFolderName = "Test_Folder" + Guid.NewGuid();
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = EnvironmentCheck.FactoryForEnvironment();
             _filesApi = _factory.Api<IFilesApi>();
             _foldersApi = _factory.Api<IFoldersApi>();
         }

--- a/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FilesApiTests.cs
@@ -17,7 +17,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = EnvironmentCheck.FactoryForEnvironment();
             _filesApi = _factory.Api<IFilesApi>();
             var foldersApi = _factory.Api<IFoldersApi>();
 

--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
@@ -18,7 +18,7 @@ namespace Lusid.Drive.Sdk.Tests
         [OneTimeSetUp]
         public void SetUp()
         {
-            _factory = LusidApiFactoryBuilder.Build("secrets.json");
+            _factory = EnvironmentCheck.FactoryForEnvironment();
             _foldersApi = _factory.Api<IFoldersApi>();
 
             _testFolderId = _foldersApi.GetRootFolder(filter: "Name eq 'SDK_Test_Folder'").Values.SingleOrDefault()?.Id;


### PR DESCRIPTION
Pipeline build fails because `secrets.json` file is empty. 
To resolve, switch behaviour based on existence of `FBN_ACCESS_TOKEN`, if env variable exists then call the correct builder.Build() method which uses the PAT, otherwise call the builder method which uses the `secrets.json` file.

I have verified by running tests locally, both with a `secrets.json`, as well as with enviornment variables with PAT, to simulate the build server setup. 