### PR TITLE
CTECH-1442 Add new method to create all folders in a given path

### DIFF
--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiExtensionsTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiExtensionsTests.cs
@@ -49,9 +49,27 @@ namespace Lusid.Drive.Sdk.Tests
         }
 
         [Test]
-        public void CreateRootDirectoryReturnsException()
+        public void CreateRootDirectoryThrowsException()
         {
             Assert.Throws(typeof(ApiException), () => _foldersApiExtensions.CreateAllFoldersInPath("/"));
+        }
+
+        [Test]
+        public void CreateLongDirectoryThrowsException()
+        {
+            var longFilePath = new string('a', 1025);
+            Assert.Throws(typeof(ApiException), () => _foldersApiExtensions.CreateAllFoldersInPath(longFilePath));
+        }
+
+        [Test]
+        public void CreateFolderOneLevelDeep()
+        {
+            var folderPath = "/" + Guid.NewGuid() + "/";
+
+            var newFolder = _foldersApiExtensions.CreateAllFoldersInPath(folderPath);
+            
+            Assert.AreEqual(folderPath.Trim('/'), newFolder.Name);
+            Assert.AreEqual("/", newFolder.Path);
         }
         
     }

--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiExtensionsTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Lusid.Drive.Sdk.Api;
+using Lusid.Drive.Sdk.Client;
+using Lusid.Drive.Sdk.Model;
+using Lusid.Drive.Sdk.Utilities;
+using NUnit.Framework;
+
+namespace Lusid.Drive.Sdk.Tests
+{
+    public class FoldersApiExtensionsTests
+    {
+        private ILusidApiFactory _factory;
+        private IFoldersApi _foldersApi;
+        private FoldersApiExtensions _foldersApiExtensions;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _factory = EnvironmentCheck.FactoryForEnvironment();
+            _foldersApi = _factory.Api<IFoldersApi>();
+            _foldersApiExtensions = new FoldersApiExtensions(_foldersApi);
+        }
+
+        [Test]
+        public void CreateNewDirectoryReturnsStorageObject()
+        {
+            var folderPath = "/test/path/to/folder/";
+            var folderName = Guid.NewGuid().ToString();
+
+            var newFolder = _foldersApiExtensions.CreateAllFoldersInPath(folderPath + folderName);
+            
+            Assert.AreEqual(folderPath.TrimEnd('/'), newFolder.Path);
+            Assert.AreEqual(folderName, newFolder.Name);
+        }
+
+        [Test]
+        public void CreateDirectoryTwiceReturnsSameObject()
+        {
+            var folderPath = "/test/path/to/folder/";
+            var folderName = Guid.NewGuid().ToString();
+
+            var newFolder = _foldersApiExtensions.CreateAllFoldersInPath(folderPath + folderName);
+            var newFolderDuplicate = _foldersApiExtensions.CreateAllFoldersInPath(folderPath + folderName);
+            
+            Assert.AreEqual(newFolder.Id, newFolderDuplicate.Id);
+        }
+
+        [Test]
+        public void CreateRootDirectoryReturnsException()
+        {
+            Assert.Throws(typeof(ApiException), () => _foldersApiExtensions.CreateAllFoldersInPath("/"));
+        }
+        
+    }
+}

--- a/sdk/Lusid.Drive.Sdk.Tests/Lusid.Drive.Sdk.Tests.csproj
+++ b/sdk/Lusid.Drive.Sdk.Tests/Lusid.Drive.Sdk.Tests.csproj
@@ -16,11 +16,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="secrets.json" CopyToOutputDirectory="Always" Condition="Exists('secrets.json')" />
-    <None Update="secrets.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lusid.Drive.Sdk\Lusid.Drive.Sdk.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="secrets.json" />
   </ItemGroup>
 </Project>

--- a/sdk/Lusid.Drive.Sdk.Tests/Lusid.Drive.Sdk.Tests.csproj
+++ b/sdk/Lusid.Drive.Sdk.Tests/Lusid.Drive.Sdk.Tests.csproj
@@ -16,11 +16,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="secrets.json" CopyToOutputDirectory="Always" Condition="Exists('secrets.json')" />
+    <None Update="secrets.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lusid.Drive.Sdk\Lusid.Drive.Sdk.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="secrets.json" />
   </ItemGroup>
 </Project>

--- a/sdk/Lusid.Drive.Sdk/Lusid.Drive.Sdk.csproj
+++ b/sdk/Lusid.Drive.Sdk/Lusid.Drive.Sdk.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Finbourne.Errors" Version="0.1.165" />
     <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0-preview.5.20278.1" />
@@ -39,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../LICENSE.md" Pack="true" PackagePath="LICENSE.md"/>
+    <None Include="../../LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
   
 </Project>

--- a/sdk/Lusid.Drive.Sdk/Utilities/ApiConfigurationBuilder.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/ApiConfigurationBuilder.cs
@@ -11,7 +11,7 @@ namespace Lusid.Drive.Sdk.Utilities
     {
         /// <summary>
         /// Builds an ApiConfiguration. using the supplied configuration file or environment
-        /// variables. If the file does not exis
+        /// variables. If the file does not exist
         ///
         /// For further details refer to https://github.com/finbourne/lusid-sdk-csharp/wiki/API-credentials
         /// </summary>

--- a/sdk/Lusid.Drive.Sdk/Utilities/FoldersApiExtensions.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/FoldersApiExtensions.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Lusid.Drive.Sdk.Api;
+using Lusid.Drive.Sdk.Client;
+using Lusid.Drive.Sdk.Model;
+
+namespace Lusid.Drive.Sdk.Utilities
+{
+    /// <summary>
+    /// Represents a collection of methods to add functionality ontop of the Folders Api
+    /// </summary>
+    public class FoldersApiExtensions
+    {
+        private readonly IFoldersApi _foldersApi;
+
+        /// <summary>
+        /// Builds a FoldersApiExtensions using a provided FoldersApi
+        /// </summary>
+        /// <param name="foldersApi"></param>
+        public FoldersApiExtensions(IFoldersApi foldersApi)
+        {
+            _foldersApi = foldersApi;
+        }
+
+        /// <summary>
+        /// Given a path, will create all folders in that path, even if some already exist.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        /// <exception cref="ApiException"></exception>
+        public StorageObject CreateAllFoldersInPath(string path)
+        {
+            path = path.Trim('/');
+            if (String.IsNullOrEmpty(path))
+                throw new ApiException(157, "Invalid Path Provided, please supply one or more folders to be created");
+
+            var folderPaths = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            StorageObject folderThusFar = null;
+            var pathThusFar = "/";
+
+            foreach (var folderPath in folderPaths)
+            {
+                // Try to create the folder
+                try
+                {
+                    var createFolder = new CreateFolder(pathThusFar, folderPath);
+                    folderThusFar = _foldersApi.CreateFolder(createFolder);
+                }
+                // catch any exceptions
+                // in the case the folder already exists, we do not want to throw as this is expected
+                catch (ApiException e)
+                {
+                    var errorResponse = e.ProblemDetails();
+                    if (errorResponse == null ||
+                        errorResponse.Code != Finbourne.Errors.ErrorCodes.FolderAlreadyExists) throw;
+                    
+                    // Get the folder that has the same name.
+                    // Do not need to worry about paging, as there can only be one folder with the same name
+                    if (pathThusFar == "/")
+                    {
+                        folderThusFar =
+                            _foldersApi.GetRootFolder(filter: $"Name eq '{folderPath}' AND Type eq 'Folder'").Values.SingleOrDefault();
+                    }
+                    else
+                    {
+                        folderThusFar = _foldersApi
+                            .GetFolderContents(id: folderThusFar!.Id,
+                                filter: $"Name eq '{folderPath}' AND Type eq 'Folder'").Values.SingleOrDefault();
+                    }
+                    
+                }
+
+                pathThusFar += folderPath + "/";
+            }
+
+            return folderThusFar;
+        }
+    }
+}

--- a/sdk/Lusid.Drive.Sdk/Utilities/FoldersApiExtensions.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/FoldersApiExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Lusid.Drive.Sdk.Api;
@@ -33,8 +34,11 @@ namespace Lusid.Drive.Sdk.Utilities
         {
             if (string.IsNullOrEmpty(path) | path == "/")
                 throw new ApiException(157, "Invalid path provided, please supply one or more folders to be created");
-
+            
             path = path.Trim('/');
+            if (path.Length > 1024)
+                throw new ApiException(157, "Path length must be less than 1024 characters");
+            
             var folderPaths = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
             StorageObject folderThusFar = null;

--- a/sdk/Lusid.Drive.Sdk/Utilities/FoldersApiExtensions.cs
+++ b/sdk/Lusid.Drive.Sdk/Utilities/FoldersApiExtensions.cs
@@ -31,10 +31,10 @@ namespace Lusid.Drive.Sdk.Utilities
         /// <exception cref="ApiException"></exception>
         public StorageObject CreateAllFoldersInPath(string path)
         {
-            path = path.Trim('/');
-            if (String.IsNullOrEmpty(path))
-                throw new ApiException(157, "Invalid Path Provided, please supply one or more folders to be created");
+            if (string.IsNullOrEmpty(path) | path == "/")
+                throw new ApiException(157, "Invalid path provided, please supply one or more folders to be created");
 
+            path = path.Trim('/');
             var folderPaths = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
             StorageObject folderThusFar = null;


### PR DESCRIPTION
This method given a path, will create every folder along that path, and return the storage object for the deepest folder. If the folder already exists in that directory, then the object is still returned.

This logic is needed for the future `EnsureFolderExists` method in the dataloaders, and thought the code is better placed here, so it can be used by other people too. 

Open to suggestions on the naming of the method