### PR TITLE
IAM-1458: Fix failing test

### DIFF
--- a/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
+++ b/sdk/Lusid.Drive.Sdk.Tests/FoldersApiTests.cs
@@ -52,12 +52,12 @@ namespace Lusid.Drive.Sdk.Tests
             var createFolder = new CreateFolder("/", folderName);
             var create = _foldersApi.CreateFolder(createFolder);
             
-            var root = _foldersApi.GetRootFolder();
-            Assert.That(root.Values.ToImmutableDictionary(x => x.Name, y => y.Id)[folderName], Is.EqualTo(create.Id));
+            var rootAfterCreate = _foldersApi.GetRootFolder(filter: $"name eq '{folderName}'");
+            Assert.That(rootAfterCreate.Values.Single().Id, Is.EqualTo(create.Id));
             
             _foldersApi.DeleteFolder(create.Id);
-            Assert.False( _foldersApi.GetRootFolder().Values.ToImmutableDictionary(x => x.Name, y => y).ContainsKey(folderName));
+            var rootAfterDelete = _foldersApi.GetRootFolder(filter: $"name eq '{folderName}'");
+            Assert.That(rootAfterDelete.Values, Has.Count.Zero);
         }
-        
     }
 }


### PR DESCRIPTION
The test does the following:
1. Create a new folder in the root folder
2. Call `GetRootFolder()` and check the folder is returned
3. Delete the folder
4. Call `GetRootFolder()` and check the folder is not returned

However, by default `GetRootFolder()` only returns 100 items in the first page and there are now more than 100 items in the root folder in this test domain, so the new folder is only sometimes returned. 

Fix is to specify a filter when calling `GetRootFolder()` so that it only returns the newly created folder